### PR TITLE
Don't force SNS to use sns.eu-west-1.amazonaws.com

### DIFF
--- a/pharo-repository/AWS-SNS/AWSSNSConfig.class.st
+++ b/pharo-repository/AWS-SNS/AWSSNSConfig.class.st
@@ -32,8 +32,4 @@ AWSSNSConfig >> defaultServiceName [
 	^ 'sns'
 ]
 
-{ #category : #accessing }
-AWSSNSConfig >> hostUrl [
-	
-	^ 'sns.eu-west-1.amazonaws.com'
-]
+


### PR DESCRIPTION
The override for hostUrl in AWSSNSConfig seems unnecessary, and makes it fail for all but eu-west-1